### PR TITLE
Pinning cowboy dependency to version 0.6.1.

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -5,5 +5,5 @@
 %%% See the NOTICE for more information.
 
 {deps,[
-    {cowboy, ".*", {git, "git://github.com/extend/cowboy.git", "master"}}
+    {cowboy, "0.6.1", {git, "git://github.com/extend/cowboy.git", "af07e048e3b3dcda1c1b80e5b664b9939100a7dd"}}
 ]}.


### PR DESCRIPTION
Using the master branch for the cowboy dependency breaks the build. Modified the dependency to grab the 0.6.1 tag commit.
